### PR TITLE
avoiding race conditions

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -67,7 +67,7 @@ class Api(object):
                 retry_after_seconds -= 1
                 log.debug("    -> sleeping: %s more seconds" % retry_after_seconds)
                 sleep(1)
-            response = http_method(url, **kwargs)
+            return self._call_api(self, http_method, url, **kwargs)
         return self._check_and_cache_response(response)
 
     def _get_items(self, endpoint, object_type, *args, **kwargs):


### PR DESCRIPTION
in case if another process already raised retry-after delay we need to re-check the headers